### PR TITLE
Chore: axios 코드에 타입 선언 / router마다 log 추가

### DIFF
--- a/src/routers/kakaoRouter.ts
+++ b/src/routers/kakaoRouter.ts
@@ -1,6 +1,5 @@
 import { Router, Request, Response } from "express";
 import { KakaoClient } from "../utils/kakao";
-import { KakaoTokenData } from "../types/kakao_login/kakaoLoginType";
 import handleLogin from "../utils/handleLogin";
 
 const router = Router();
@@ -24,13 +23,15 @@ router.post("/login", async (req: Request, res: Response) => {
   console.log("POST /kakao/login start");
   try {
     const { code }: { code: string } = req.body;
-    const kakaoToken: KakaoTokenData = await KakaoClient.getKakaoToken(code);
-    const userData = await KakaoClient.getUserData(kakaoToken);
-
-    console.log("최종적으로 사용할 userData: ", userData);
-
-    const dataWithJWT = await handleLogin(userData);
-    res.status(200).json(dataWithJWT);
+    const kakaoToken = await KakaoClient.getKakaoToken(code);
+    if (kakaoToken) {
+      const userData = await KakaoClient.getUserData(kakaoToken);
+      if (userData) {
+        console.log("최종적으로 사용할 userData: ", userData);
+        const dataWithJWT = await handleLogin(userData);
+        res.status(200).json(dataWithJWT);
+      }
+    }
   } catch (err) {
     console.error("POST /kakao/login Error: ", err);
   }

--- a/src/routers/kakaoRouter.ts
+++ b/src/routers/kakaoRouter.ts
@@ -5,7 +5,6 @@ import handleLogin from "../utils/handleLogin";
 const router = Router();
 
 router.get("/url", (req: Request, res: Response) => {
-  console.log("GET /kakao/url start");
   try {
     const url = KakaoClient.getAuthCodeUrl();
     res.status(200).json({
@@ -20,14 +19,13 @@ router.get("/url", (req: Request, res: Response) => {
 });
 
 router.post("/login", async (req: Request, res: Response) => {
-  console.log("POST /kakao/login start");
   try {
     const { code }: { code: string } = req.body;
     const kakaoToken = await KakaoClient.getKakaoToken(code);
     if (kakaoToken) {
       const userData = await KakaoClient.getUserData(kakaoToken);
       if (userData) {
-        console.log("최종적으로 사용할 userData: ", userData);
+        console.log("POST /kakao/login success");
         const dataWithJWT = await handleLogin(userData);
         res.status(200).json(dataWithJWT);
       }

--- a/src/routers/tokenRouter.ts
+++ b/src/routers/tokenRouter.ts
@@ -11,6 +11,9 @@ const router = Router();
 // 이를 위해 token 검증을 수행하는 엔드포인트다.
 router.get("/validate", (req: Request, res: Response) => {
   if (!req.headers.authorization) {
+    console.log(
+      "GET /token/validate 400: authorization 헤더에 jwt가 담겨있지 않습니다"
+    );
     res.status(400).json({
       ok: false,
       message: "authorization 헤더에 jwt가 담겨있지 않습니다",
@@ -19,12 +22,14 @@ router.get("/validate", (req: Request, res: Response) => {
   }
   const accessToken = req.headers.authorization.split(" ")[1];
   if (verifyAccessToken(accessToken)) {
+    console.log("GET /token/validate 200: accessToken이 만료되지 않았습니다");
     res.status(200).json({
       ok: true,
       message: "accessToken이 만료되지 않았습니다",
     });
     return;
   } else {
+    console.log("GET /token/validate 401: accessToken이 만료되었습니다");
     res.status(401).json({
       ok: false,
       message: "accessToken이 만료되었습니다",
@@ -48,12 +53,16 @@ router.get("/refresh", async (req: Request, res: Response) => {
       if (isVerifyRefreshToken) {
         // accessToken은 만료되었지만, refreshToken은 만료되지 않은 경우
         const newAccessToken = generateAccessToken(decoded.id);
+        console.log("GET /token/refresh 200: 새 accessToken을 발급했습니다");
         res.status(200).json({
           accessToken: newAccessToken,
         });
       } else {
         // 둘 다 만료된 경우
         // FE쪽 로그아웃 시켜야 함
+        console.log(
+          "GET /token/refresh 401: accessToken, refreshToken 모두 만료되었습니다"
+        );
         res.status(401).json({
           ok: false,
           message: "Both tokens expired",
@@ -61,6 +70,7 @@ router.get("/refresh", async (req: Request, res: Response) => {
       }
     } else {
       // accessToken을 디코딩 한 결과가 비어있는 경우
+      console.log("GET /token/refresh 400: accessToken에 문제가 있습니다");
       res.status(400).json({
         ok: false,
         message: "No Authorized",
@@ -68,6 +78,9 @@ router.get("/refresh", async (req: Request, res: Response) => {
     }
   } else {
     // refreshToken과 accessToken 모두 존재하지 않는 경우
+    console.log(
+      "GET /token/refresh 400: accessToken과 refreshToken이 요청 headers에 존재하지 않습니다"
+    );
     res.status(400).json({
       ok: false,
       message: "Access token and refresh token not found",

--- a/src/types/kakao_login/kakaoLoginType.ts
+++ b/src/types/kakao_login/kakaoLoginType.ts
@@ -13,6 +13,15 @@ export type KakaoTokenData = {
   refresh_token: string;
 };
 
+export type KakaoUserData = {
+  id: string;
+  kakao_account: {
+    profile: {
+      nickname: string;
+    };
+  };
+};
+
 export type UserData = {
   id: string;
   nickname: string;


### PR DESCRIPTION
### 변경사항
- `kakao.ts`: `axios` 라이브러리로 카카오 로그인 API와 통신하는 부분에서 제네릭 문법을 사용해 `AxiosResponse`를 명확하게 지정해줬고, `isAxiosError()` 함수를 사용해 `catch`문의 `error`를 `AxiosError`로 명확하게 지정해줬다.
- `kakaoRouter.ts`, `tokenRouter.ts`: 기존에 있던 log 대신, 각 API들이 성공했는지, 실패했다면 무슨 원인으로 실패했는지를 나타내는 로그만 간략하게 하나씩 가지도록 변경했다. 여러 API 호출이 발생할 경우, 순서대로 잘 실행되었는지 / 어떤 API에서 오류가 발생했는지 원활하게 확인할 수 있을 것으로 기대한다.

`kakao.ts`

```js
try {
      const data = await axios.post<KakaoResult>( ... );
      if (data.data) {
        const tokenData: KakaoTokenData = { ... };
      }
    } catch (err) {
      if (isAxiosError(err)) { ... }
    }
```